### PR TITLE
Suppress a "unused parameter 'kay'" warning on clang++

### DIFF
--- a/picojson.h
+++ b/picojson.h
@@ -654,7 +654,7 @@ namespace picojson {
       return _parse(*this, in);
     }
     bool parse_object_start() { return true; }
-    template <typename Iter> bool parse_object_item(input<Iter>& in, const std::string& key) {
+    template <typename Iter> bool parse_object_item(input<Iter>& in, const std::string&) {
       return _parse(*this, in);
     }
   private:


### PR DESCRIPTION
Hi, kazuho,

Thank you for your great library, but I found that there is a warning produced by clang++ with -Wall -Wextra, so I have fixed it on my branch.

Can you review my change please?

Regards,
gfx
