### PR TITLE
fix return type of expect.

### DIFF
--- a/picojson.h
+++ b/picojson.h
@@ -386,7 +386,7 @@ namespace picojson {
 	}
       }
     }
-    int expect(int expect) {
+    bool expect(int expect) {
       skip_ws();
       if (getc() != expect) {
 	ungetc();


### PR DESCRIPTION
originally reported by @chandrashekhar-vastrad

i think this doesn't happen on GCC, but happen on Visual Studio.
