### PR TITLE
Removed unnecessary iterator copy in input::getc()

### DIFF
--- a/picojson.h
+++ b/picojson.h
@@ -377,7 +377,8 @@ namespace picojson {
       if (last_ch_ == '\n') {
 	line_++;
       }
-      last_ch_ = *cur_++ & 0xff;
+      last_ch_ = *cur_ & 0xff;
+      ++cur_;
       return last_ch_;
     }
     void ungetc() {


### PR DESCRIPTION
Replaced the post-increment operator++ usage in input::getc to avoid an iterator copy.
