### PR TITLE
fix bug with value and key-value endings

### DIFF
--- a/picojson.h
+++ b/picojson.h
@@ -527,6 +527,9 @@ namespace picojson {
     }
     size_t idx = 0;
     do {
+      if (in.expect(']')) {
+        return true;
+      }
       if (! ctx.parse_array_item(in, idx)) {
 	return false;
       }
@@ -544,6 +547,9 @@ namespace picojson {
     }
     do {
       std::string key;
+      if (in.expect('}')) {
+        return true;
+      }
       if (! in.expect('"')
 	  || ! _parse_string(key, in)
 	  || ! in.expect(':')) {


### PR DESCRIPTION
fix bug with incorect parsing of [1, 2, 3, ] and {"a" : "b", }
