### PR TITLE
silently convert inf and NaN values to null

### DIFF
--- a/picojson.h
+++ b/picojson.h
@@ -38,6 +38,7 @@
 #include <cstring>
 #include <iostream>
 #include <iterator>
+#include <limits>
 #include <map>
 #include <string>
 #include <vector>
@@ -139,6 +140,13 @@ namespace picojson {
   }
   
   inline value::value(double n) : type_(number_type) {
+	if (std::numeric_limits<double>::is_iec559) {
+		if (std::abs(n) == std::numeric_limits<double>::infinity() ||
+		    std::abs(n) != std::abs(n) /* will not work with -ffast-math*/) {
+			type_ = null_type;
+			return;
+		}
+	}
     u_.number_ = n;
   }
   


### PR DESCRIPTION
Hi,

Recently had an issue where Inf and NaN values were being put into our JSON strings. Inf and Nan values are not valid JSON. This patch will convert them to null objects.
If users want, it might be an idea to have an #ifdef to convert them to strings instead.

Thanks,
Mark
