### PR TITLE
fix build error

### DIFF
--- a/picojson.h
+++ b/picojson.h
@@ -29,7 +29,11 @@
 #define picojson_h
 
 #include <algorithm>
-#include <cmath>
+#if __cplusplus >= 201103L
+# include <cmath>  // for std::isnan, std::isinf
+#else
+# include <math.h> // for isnan, isinf
+#endif
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>


### PR DESCRIPTION
I got build error on mingw32/windows.

https://gist.github.com/mattn/2652a97bc8c8d733e525

This mean, if compiler doesn't have c++11(or doesn't specified -std=c++11), cmath won't provide isanf/isnan to "C" namespace.

https://github.com/kazuho/picojson/blob/master/picojson.h#L168-L172

If __cplusplus less than 201103L, we should define isnan/isinf.
