### PR TITLE
Add workaround for defective <cmath>

### DIFF
--- a/picojson.h
+++ b/picojson.h
@@ -194,7 +194,7 @@ namespace picojson {
     if (
 #ifdef _MSC_VER
         ! _finite(n)
-#elif __cplusplus>=201103L
+#elif __cplusplus>=201103L || !(defined(isnan) && defined(isinf))
 		std::isnan(n) || std::isinf(n)
 #else
         isnan(n) || isinf(n)


### PR DESCRIPTION
For older compilers (pre-C++11) picojson accesses the `isnan` and `isinf` functions by including `<math.h>`. But this can lead to problems if the user included `<cmath>` before including `"picojson.h"`: some implementations of `<cmath>` include `<math.h>` themselves and then undefine some macros like `isnan` and `isinf` as not needed before C++11. This happens at least for:
g++ (rev2, Built by MinGW-builds project) 4.8.0

This workaround relies on the fact that if the `<math.h>` include inside `"picojsoon.h"` fails because of a previous `<cmath>` include, then `std::isnan` and `std::isinf` are available. And if in contrast `<math.h>` is properly included, `isnan` and `isinf` are implemented as preprocessor macros.
