### PR TITLE
Fix MSVC /W4 warnings

### DIFF
--- a/picojson.h
+++ b/picojson.h
@@ -80,6 +80,8 @@ extern "C" {
     #define SNPRINTF _snprintf_s
     #pragma warning(push)
     #pragma warning(disable : 4244) // conversion from int to char
+    #pragma warning(disable : 4127) // conditional expression is constant
+    #pragma warning(disable : 4702) // unreachable code
 #else
     #define SNPRINTF snprintf
 #endif


### PR DESCRIPTION
Another fix for MSVC /W4 warnings about constant conditionals and unreachable code. Doesn't address int64 issue to keep the patch small and simple.
