### PR TITLE
Make value types replacable (by providing type traits)

### DIFF
--- a/picojson.h
+++ b/picojson.h
@@ -108,7 +108,7 @@ namespace picojson {
   
   namespace defaults {
 
-    struct number_traits {
+    struct default_number_traits {
       typedef double value_type;
       static value_type default_value() { return 0.0; }
       static void construct(value_type &slot, value_type n) {
@@ -157,7 +157,7 @@ namespace picojson {
     };
 
     struct type_traits {
-      typedef number_traits number_traits;
+      typedef default_number_traits number_traits;
     };
 
   }


### PR DESCRIPTION
Until now, picojson has fixed the types used to represent various types of JSON (e.g. number, string, boolean, ...).  But there has been a constant request to _replace_ how the numbers are represented (which has been handled to some extent by adding the `PICOJSON_USE_INT64` flag).

The ideal way to answer such requests is to templatize the `value` type so that the types used for storing the JSON values via type traits (using `#ifdef`s to switch between the types is not an answer, since it would cause compile or link-time errors when more than one module uses picojson with different set of types).

This PR does that.  It implements a type trait (only for numbers at the moment), so that users can define their own set of traits and use the templatized value type (`value_t<TraitsT>`).

I am going to merge this branch to master if I anybody actually starts using the feature (and if he/she provides the source code that can be used for testing the feature).
