### PR TITLE
Caj/type traits gmp

### DIFF
--- a/examples/gmp-test.cc
+++ b/examples/gmp-test.cc
@@ -1,0 +1,80 @@
+#include "../picojson.h"
+#include "gmp-traits.h"
+
+using namespace std;
+using namespace picojson;
+
+using namespace std;
+  
+static bool success = true;
+static int test_num = 0;
+
+static void ok(bool b, const char* name = "")
+{
+  if (! b)
+    success = false;
+  printf("%s %d - %s\n", b ? "ok" : "ng", ++test_num, name);
+}
+
+static void done_testing()
+{
+  printf("1..%d\n", test_num);
+}
+
+template <typename T> void is(const T& x, const T& y, const char* name = "")
+{
+  if (x == y) {
+    ok(true, name);
+  } else {
+    ok(false, name);
+  }
+}
+
+int main(void)
+{
+    typedef picojson::value_t<large_int_type_traits> gmp_value;
+    
+#if PICOJSON_USE_LOCALE
+  setlocale(LC_ALL, "");
+#endif
+  
+  // constructors
+#define TEST(expr, expected) \
+    is(gmp_value expr .serialize(), string(expected), "picojson::value" #expr)
+  
+#define hugestr "1234567890123456789012345678901234567890"
+  mpz_class hugeint(hugestr);
+  TEST( (true),  "true");
+  TEST( (false), "false");
+  TEST( (new string_large_int(42.0)),   "42");
+  TEST( (new string_large_int(42)),   "42");
+  TEST( (new string_large_int(hugeint)), hugestr);
+  TEST( (string("hello")), "\"hello\"");
+  TEST( ("hello"), "\"hello\"");
+  TEST( ("hello", 4), "\"hell\"");
+    
+#undef TEST
+  
+#define TEST(in, type, cmp, serialize_test) {				\
+    gmp_value v;							\
+    const char* s = in;							\
+    string err = picojson::parse(v, s, s + strlen(s));			\
+    ok(err.empty(), in " no error");					\
+    ok(v.is<type>(), in " check type");					\
+    is<type>(v.get<type>(), cmp, in " correct output");			\
+    is(*s, '\0', in " read to eof");					\
+    if (serialize_test) {						\
+      is(v.serialize(), string(in), in " serialize");			\
+    }									\
+  }
+  TEST("false", bool, false, true);
+  TEST("true", bool, true, true);
+  TEST("90.5", string_large_int, string_large_int(90.5), false);
+  TEST("90", string_large_int, string_large_int(mpz_class("90")), false);
+  TEST(hugestr, string_large_int, string_large_int(hugeint), false);
+#undef TEST
+
+  done_testing();
+
+  return success ? 0 : 1;
+}

--- a/examples/gmp-test.cc
+++ b/examples/gmp-test.cc
@@ -46,9 +46,9 @@ int main(void)
   mpz_class hugeint(hugestr);
   TEST( (true),  "true");
   TEST( (false), "false");
-  TEST( (new string_large_int(42.0)),   "42");
-  TEST( (new string_large_int(42)),   "42");
-  TEST( (new string_large_int(hugeint)), hugestr);
+  TEST( (new gmp_double_pair(42.0)),   "42");
+  TEST( (new gmp_double_pair(42)),   "42");
+  TEST( (new gmp_double_pair(hugeint)), hugestr);
   TEST( (string("hello")), "\"hello\"");
   TEST( ("hello"), "\"hello\"");
   TEST( ("hello", 4), "\"hell\"");
@@ -69,9 +69,9 @@ int main(void)
   }
   TEST("false", bool, false, true);
   TEST("true", bool, true, true);
-  TEST("90.5", string_large_int, string_large_int(90.5), false);
-  TEST("90", string_large_int, string_large_int(mpz_class("90")), false);
-  TEST(hugestr, string_large_int, string_large_int(hugeint), false);
+  TEST("90.5", gmp_double_pair, gmp_double_pair(90.5), false);
+  TEST("90", gmp_double_pair, gmp_double_pair(mpz_class("90")), false);
+  TEST(hugestr, gmp_double_pair, gmp_double_pair(hugeint), false);
 #undef TEST
 
   done_testing();

--- a/examples/gmp-traits.h
+++ b/examples/gmp-traits.h
@@ -1,0 +1,154 @@
+#include <string>
+#include <algorithm>
+#include <math.h>
+#include <stdio.h>
+#include <gmpxx.h>
+#include <sstream>
+
+class string_large_int
+{
+    mpz_class large_int;
+    double value;
+    bool use_double;
+public:
+    string_large_int()
+    : value(0), use_double(true)
+    { }
+    
+    explicit string_large_int(double d)
+    : value(d), use_double(true)
+    { }    
+    
+    explicit string_large_int(const mpz_class& bigint)
+    : large_int(bigint), value(0), use_double(false)
+    { }
+    
+    bool evaluate_as_boolean() const
+    { 
+        if(use_double)
+            return value == 0;
+        else
+            return large_int == 0;
+    }
+    
+    static std::pair<string_large_int*, bool> from_str_double(const std::string& s)
+    {
+        char* endp;
+        double f = strtod(s.c_str(), &endp);
+        if(endp == s.c_str() + s.size()) {
+            return std::make_pair(new string_large_int(f), true);
+        }
+        return std::make_pair(new string_large_int(0.0), false);
+    }
+    static std::pair<string_large_int*, bool> from_str(const std::string& s)
+    {
+        if(s.find(".") != std::string::npos)
+        {
+            return from_str_double(s);
+        }
+        else
+        {
+            try
+            {
+                // The following code is just designed to turn any valid
+                // json integer into a gmp number.
+                int loc = s.find_first_of("eE");
+                if(loc == std::string::npos)
+                {
+                    return std::make_pair(new string_large_int(mpz_class(s)), true);
+                }
+                
+                std::string arg1(s.begin(), s.begin() + loc);
+                std::string arg2(s.begin() + loc + 1, s.end());
+
+                std::cerr << arg1 << ":" << arg2 << ":\n";
+                
+                if(arg1.empty() || arg2.empty())
+                    throw std::invalid_argument("?");
+                
+                char* endp;
+                long longexp = strtol(s.c_str() + loc + 1, &endp, 10);
+                if(endp != s.c_str() + s.size())
+                    throw std::invalid_argument("?");
+                
+                if(longexp < 0)
+                {
+                    // Back to a double!
+                    return from_str_double(s);
+                }
+                    
+                mpz_class exponent;
+                mpz_ui_pow_ui(exponent.get_mpz_t(), 10, longexp);
+                mpz_class result = mpz_class(arg1) * exponent;
+                return std::make_pair(new string_large_int(result), true);
+            }
+            catch(std::invalid_argument)
+            { return std::make_pair(new string_large_int(0.0), false); }
+        }
+    }
+    
+    std::string to_str() const
+    {
+        if(use_double)
+        {
+            char buf[256];
+            double tmp;
+            snprintf(buf, sizeof(buf), fabs(value) < (1ULL << 53) && modf(value, &tmp) == 0 ? "%.f" : "%.17g", value);
+            return buf;
+        }
+        else
+        {
+            std::ostringstream oss;
+            oss << large_int;
+            return oss.str();
+        }   
+    }
+    
+    friend std::ostream& operator<<(std::ostream& o, const string_large_int& s)
+    {
+        if(s.use_double)
+            return o << s.value;
+        else
+            return o << s.large_int;
+    }
+    
+    friend bool operator==(const string_large_int& lhs, const string_large_int& rhs)
+    {
+        if(lhs.use_double != rhs.use_double)
+            return false;
+        if(lhs.use_double)
+            return lhs.value == rhs.value;
+        else
+            return lhs.large_int == rhs.large_int;
+    }
+};
+
+
+template<typename T>
+struct wrap_number_traits {
+  typedef T* value_type;
+  typedef T return_type;
+  static return_type& to_return_type(value_type& t){
+    return *t;
+  }
+  static value_type default_value() { return new T(); }
+  static void construct(value_type &slot, value_type n) {
+    slot = new T(*n);
+  }
+  
+  static void destruct(value_type &slot) {delete slot; }
+  static bool evaluate_as_boolean(value_type n) {
+    return n->evaluate_as_boolean();
+  }
+  static std::pair<value_type, bool> from_str(const std::string& s) {
+      return T::from_str(s);
+  }
+
+  static std::string to_str(value_type n) {
+      return n->to_str();
+  }
+};
+
+struct large_int_type_traits {
+  typedef wrap_number_traits<string_large_int> number_traits;
+};

--- a/examples/gmp-traits.h
+++ b/examples/gmp-traits.h
@@ -5,21 +5,21 @@
 #include <gmpxx.h>
 #include <sstream>
 
-class string_large_int
+class gmp_double_pair
 {
     mpz_class large_int;
     double value;
     bool use_double;
 public:
-    string_large_int()
+    gmp_double_pair()
     : value(0), use_double(true)
     { }
     
-    explicit string_large_int(double d)
+    explicit gmp_double_pair(double d)
     : value(d), use_double(true)
     { }    
     
-    explicit string_large_int(const mpz_class& bigint)
+    explicit gmp_double_pair(const mpz_class& bigint)
     : large_int(bigint), value(0), use_double(false)
     { }
     
@@ -31,16 +31,16 @@ public:
             return large_int == 0;
     }
     
-    static std::pair<string_large_int*, bool> from_str_double(const std::string& s)
+    static std::pair<gmp_double_pair*, bool> from_str_double(const std::string& s)
     {
         char* endp;
         double f = strtod(s.c_str(), &endp);
         if(endp == s.c_str() + s.size()) {
-            return std::make_pair(new string_large_int(f), true);
+            return std::make_pair(new gmp_double_pair(f), true);
         }
-        return std::make_pair(new string_large_int(0.0), false);
+        return std::make_pair(new gmp_double_pair(0.0), false);
     }
-    static std::pair<string_large_int*, bool> from_str(const std::string& s)
+    static std::pair<gmp_double_pair*, bool> from_str(const std::string& s)
     {
         if(s.find(".") != std::string::npos)
         {
@@ -55,7 +55,7 @@ public:
                 int loc = s.find_first_of("eE");
                 if(loc == std::string::npos)
                 {
-                    return std::make_pair(new string_large_int(mpz_class(s)), true);
+                    return std::make_pair(new gmp_double_pair(mpz_class(s)), true);
                 }
                 
                 std::string arg1(s.begin(), s.begin() + loc);
@@ -80,10 +80,10 @@ public:
                 mpz_class exponent;
                 mpz_ui_pow_ui(exponent.get_mpz_t(), 10, longexp);
                 mpz_class result = mpz_class(arg1) * exponent;
-                return std::make_pair(new string_large_int(result), true);
+                return std::make_pair(new gmp_double_pair(result), true);
             }
             catch(std::invalid_argument)
-            { return std::make_pair(new string_large_int(0.0), false); }
+            { return std::make_pair(new gmp_double_pair(0.0), false); }
         }
     }
     
@@ -104,7 +104,7 @@ public:
         }   
     }
     
-    friend std::ostream& operator<<(std::ostream& o, const string_large_int& s)
+    friend std::ostream& operator<<(std::ostream& o, const gmp_double_pair& s)
     {
         if(s.use_double)
             return o << s.value;
@@ -112,7 +112,7 @@ public:
             return o << s.large_int;
     }
     
-    friend bool operator==(const string_large_int& lhs, const string_large_int& rhs)
+    friend bool operator==(const gmp_double_pair& lhs, const gmp_double_pair& rhs)
     {
         if(lhs.use_double != rhs.use_double)
             return false;
@@ -150,5 +150,5 @@ struct wrap_number_traits {
 };
 
 struct large_int_type_traits {
-  typedef wrap_number_traits<string_large_int> number_traits;
+  typedef wrap_number_traits<gmp_double_pair> number_traits;
 };

--- a/examples/iostream-gmp.cc
+++ b/examples/iostream-gmp.cc
@@ -50,8 +50,8 @@ int main(void)
     std::cout << "input is null" << std::endl;
   } else if (v.is<bool>()) {
     std::cout << "input is " << (v.get<bool>() ? "true" : "false") << std::endl;
-  } else if (v.is<string_large_int>()) {
-    std::cout << "input is " << v.get<string_large_int>() << std::endl;
+  } else if (v.is<gmp_double_pair>()) {
+    std::cout << "input is " << v.get<gmp_double_pair>() << std::endl;
   } else if (v.is<std::string>()) {
     std::cout << "input is " << v.get<std::string>() << std::endl;
   } else if (v.is<gmp_value::array>()) {

--- a/examples/iostream-gmp.cc
+++ b/examples/iostream-gmp.cc
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2009-2010 Cybozu Labs, Inc.
+ * Copyright 2011-2014 Kazuho Oku
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "../picojson.h"
+#include "gmp-traits.h"
+
+int main(void)
+{
+  typedef picojson::value_t<large_int_type_traits> gmp_value;
+  gmp_value v;
+  
+  // read json value from stream
+  std::cin >> v;
+  if (std::cin.fail()) {
+    std::cerr << picojson::get_last_error() << std::endl;
+    return 1;
+  }
+  
+  // dump json object
+  std::cout << "---- dump input ----" << std::endl;
+  std::cout << v << std::endl;
+
+  // accessors
+  std::cout << "---- analyzing input ----" << std::endl;
+  if (v.is<picojson::null>()) {
+    std::cout << "input is null" << std::endl;
+  } else if (v.is<bool>()) {
+    std::cout << "input is " << (v.get<bool>() ? "true" : "false") << std::endl;
+  } else if (v.is<gmp_value::value>()) {
+    std::cout << "input is " << *v.get<gmp_value::value>() << std::endl;
+  } else if (v.is<std::string>()) {
+    std::cout << "input is " << v.get<std::string>() << std::endl;
+  } else if (v.is<gmp_value::array>()) {
+    std::cout << "input is an array" << std::endl;
+    const gmp_value::array& a = v.get<gmp_value::array>();
+    for (gmp_value::array::const_iterator i = a.begin(); i != a.end(); ++i) {
+      std::cout << "  " << *i << std::endl;
+    }
+  } else if (v.is<gmp_value::object>()) {
+    std::cout << "input is an object" << std::endl;
+    const gmp_value::object& o = v.get<gmp_value::object>();
+    for (gmp_value::object::const_iterator i = o.begin(); i != o.end(); ++i) {
+      std::cout << i->first << "  " << i->second << std::endl;
+    }
+  }
+  
+  return 0;
+}

--- a/examples/iostream-gmp.cc
+++ b/examples/iostream-gmp.cc
@@ -50,8 +50,8 @@ int main(void)
     std::cout << "input is null" << std::endl;
   } else if (v.is<bool>()) {
     std::cout << "input is " << (v.get<bool>() ? "true" : "false") << std::endl;
-  } else if (v.is<gmp_value::value>()) {
-    std::cout << "input is " << *v.get<gmp_value::value>() << std::endl;
+  } else if (v.is<string_large_int>()) {
+    std::cout << "input is " << v.get<string_large_int>() << std::endl;
   } else if (v.is<std::string>()) {
     std::cout << "input is " << v.get<std::string>() << std::endl;
   } else if (v.is<gmp_value::array>()) {

--- a/picojson.h
+++ b/picojson.h
@@ -106,13 +106,62 @@ namespace picojson {
 
   struct null {};
   
-  class value {
+  namespace defaults {
+
+    struct number_traits {
+      typedef double value_type;
+      static value_type default_value() { return 0.0; }
+      static void construct(value_type &slot, value_type n) {
+        if (
+#ifdef _MSC_VER
+            ! _finite(n)
+#elif __cplusplus>=201103L || !(defined(isnan) && defined(isinf))
+            std::isnan(n) || std::isinf(n)
+#else
+            isnan(n) || isinf(n)
+#endif
+        ) {
+          throw std::overflow_error("");
+        }
+        slot = n;
+      }
+      static void destruct(value_type &slot) {}
+      static bool evaluate_as_boolean(value_type n) {
+        return n != 0;
+      }
+      static std::string to_str(value_type n) {
+        char buf[256];
+        double tmp;
+        SNPRINTF(buf, sizeof(buf), fabs(n) < (1ULL << 53) && modf(n, &tmp) == 0 ? "%.f" : "%.17g", n);
+#if PICOJSON_USE_LOCALE
+        char *decimal_point = localeconv()->decimal_point;
+        if (strcmp(decimal_point, ".") != 0) {
+          size_t decimal_point_len = strlen(decimal_point);
+          for (char *p = buf; *p != '\0'; ++p) {
+            if (strncmp(p, decimal_point, decimal_point_len) == 0) {
+              return std::string(buf, p) + "." + (p + decimal_point_len);
+            }
+          }
+        }
+#endif
+        return buf;
+      }
+    };
+
+    struct type_traits {
+      typedef number_traits number_traits;
+    };
+
+  }
+
+  template <typename TraitsT> class value_t {
   public:
-    typedef std::vector<value> array;
-    typedef std::map<std::string, value> object;
+    typedef std::vector<value_t> array;
+    typedef std::map<std::string, value_t> object;
     union _storage {
+      null null_;
       bool boolean_;
-      double number_;
+      typename TraitsT::number_traits::value_type number_;
 #ifdef PICOJSON_USE_INT64
       int64_t int64_;
 #endif
@@ -124,30 +173,30 @@ namespace picojson {
     int type_;
     _storage u_;
   public:
-    value();
-    value(int type, bool);
-    explicit value(bool b);
+    value_t();
+    value_t(int type, bool);
+    explicit value_t(bool b);
 #ifdef PICOJSON_USE_INT64
-    explicit value(int64_t i);
+    explicit value_t(int64_t i);
 #endif
-    explicit value(double n);
-    explicit value(const std::string& s);
-    explicit value(const array& a);
-    explicit value(const object& o);
-    explicit value(const char* s);
-    value(const char* s, size_t len);
-    ~value();
-    value(const value& x);
-    value& operator=(const value& x);
-    void swap(value& x);
+    explicit value_t(const typename TraitsT::number_traits::value_type& n);
+    explicit value_t(const std::string& s);
+    explicit value_t(const array& a);
+    explicit value_t(const object& o);
+    explicit value_t(const char* s);
+    value_t(const char* s, size_t len);
+    ~value_t();
+    value_t(const value_t& x);
+    value_t& operator=(const value_t& x);
+    void swap(value_t& x);
     template <typename T> bool is() const;
     template <typename T> const T& get() const;
     template <typename T> T& get();
     bool evaluate_as_boolean() const;
-    const value& get(size_t idx) const;
-    const value& get(const std::string& key) const;
-    value& get(size_t idx);
-    value& get(const std::string& key);
+    const value_t& get(size_t idx) const;
+    const value_t& get(const std::string& key) const;
+    value_t& get(size_t idx);
+    value_t& get(const std::string& key);
 
     bool contains(size_t idx) const;
     bool contains(const std::string& key) const;
@@ -155,22 +204,25 @@ namespace picojson {
     template <typename Iter> void serialize(Iter os, bool prettify = false) const;
     std::string serialize(bool prettify = false) const;
   private:
-    template <typename T> value(const T*); // intentionally defined to block implicit conversion of pointer to bool
+    template <typename T> value_t(const T*); // intentionally defined to block implicit conversion of pointer to bool
     template <typename Iter> static void _indent(Iter os, int indent);
     template <typename Iter> void _serialize(Iter os, int indent) const;
     std::string _serialize(int indent) const;
   };
-  
+
+  typedef value_t<defaults::type_traits> value;
   typedef value::array array;
   typedef value::object object;
   
-  inline value::value() : type_(null_type) {}
+  template <typename TraitsT>
+  inline value_t<TraitsT>::value_t() : type_(null_type) {}
   
-  inline value::value(int type, bool) : type_(type) {
+  template <typename TraitsT>
+  inline value_t<TraitsT>::value_t(int type, bool) : type_(type) {
     switch (type) {
 #define INIT(p, v) case p##type: u_.p = v; break
       INIT(boolean_, false);
-      INIT(number_, 0.0);
+      INIT(number_, TraitsT::number_traits::default_value());
 #ifdef PICOJSON_USE_INT64
       INIT(int64_, 0);
 #endif
@@ -181,54 +233,56 @@ namespace picojson {
     default: break;
     }
   }
-  
-  inline value::value(bool b) : type_(boolean_type) {
+
+  template <typename TraitsT>
+  inline value_t<TraitsT>::value_t(bool b) : type_(boolean_type) {
     u_.boolean_ = b;
   }
 
 #ifdef PICOJSON_USE_INT64
-  inline value::value(int64_t i) : type_(int64_type) {
+  template <typename TraitsT>
+  inline value_t<TraitsT>::value_t(int64_t i) : type_(int64_type) {
     u_.int64_ = i;
   }
 #endif
 
-  inline value::value(double n) : type_(number_type) {
-    if (
-#ifdef _MSC_VER
-        ! _finite(n)
-#elif __cplusplus>=201103L || !(defined(isnan) && defined(isinf))
-		std::isnan(n) || std::isinf(n)
-#else
-        isnan(n) || isinf(n)
-#endif
-        ) {
-      throw std::overflow_error("");
-    }
-    u_.number_ = n;
+  template <typename TraitsT>
+  inline value_t<TraitsT>::value_t(const typename TraitsT::number_traits::value_type& n)
+  : type_(number_type) {
+    TraitsT::number_traits::construct(u_.number_, n);
   }
   
-  inline value::value(const std::string& s) : type_(string_type) {
+  template <typename TraitsT>
+  inline value_t<TraitsT>::value_t(const std::string& s) : type_(string_type) {
     u_.string_ = new std::string(s);
   }
   
-  inline value::value(const array& a) : type_(array_type) {
+  template <typename TraitsT>
+  inline value_t<TraitsT>::value_t(const array& a) : type_(array_type) {
     u_.array_ = new array(a);
   }
   
-  inline value::value(const object& o) : type_(object_type) {
+  template <typename TraitsT>
+  inline value_t<TraitsT>::value_t(const object& o) : type_(object_type) {
     u_.object_ = new object(o);
   }
   
-  inline value::value(const char* s) : type_(string_type) {
+  template <typename TraitsT>
+  inline value_t<TraitsT>::value_t(const char* s) : type_(string_type) {
     u_.string_ = new std::string(s);
   }
   
-  inline value::value(const char* s, size_t len) : type_(string_type) {
+  template <typename TraitsT>
+  inline value_t<TraitsT>::value_t(const char* s, size_t len) : type_(string_type) {
     u_.string_ = new std::string(s, len);
   }
   
-  inline value::~value() {
+  template <typename TraitsT>
+  inline value_t<TraitsT>::~value_t() {
     switch (type_) {
+    case number_type:
+      TraitsT::number_traits::destruct(u_.number_);
+      break;
 #define DEINIT(p) case p##type: delete u_.p; break
       DEINIT(string_);
       DEINIT(array_);
@@ -238,8 +292,12 @@ namespace picojson {
     }
   }
   
-  inline value::value(const value& x) : type_(x.type_) {
+  template <typename TraitsT>
+  inline value_t<TraitsT>::value_t(const value_t& x) : type_(x.type_) {
     switch (type_) {
+    case number_type:
+      TraitsT::number_traits::construct(u_.number_, x.u_.number_);
+      break;
 #define INIT(p, v) case p##type: u_.p = v; break
       INIT(string_, new std::string(*x.u_.string_));
       INIT(array_, new array(*x.u_.array_));
@@ -251,71 +309,96 @@ namespace picojson {
     }
   }
   
-  inline value& value::operator=(const value& x) {
+  template <typename TraitsT>
+  inline value_t<TraitsT>& value_t<TraitsT>::operator=(const value_t<TraitsT>& x) {
     if (this != &x) {
-      this->~value();
-      new (this) value(x);
+      this->~value_t();
+      new (this) value_t(x);
     }
     return *this;
   }
   
-  inline void value::swap(value& x) {
+  template <typename TraitsT>
+  inline void value_t<TraitsT>::swap(value_t<TraitsT>& x) {
     std::swap(type_, x.type_);
     std::swap(u_, x.u_);
   }
   
-#define IS(ctype, jtype)			     \
-  template <> inline bool value::is<ctype>() const { \
-    return type_ == jtype##_type;		     \
+  template <typename TraitsT, typename T> struct _accessor {
+    static bool is(int type);
+    static T& get(int& type, typename value_t<TraitsT>::_storage& u);
+  };
+
+#define ACCESSOR(ctype, jtype, jvar)			     \
+  template <typename TraitsT> \
+  struct _accessor<TraitsT, ctype> { \
+    static bool is(int type) { \
+      return type == jtype##_type;		     \
+    } \
+    static ctype& get(int& type, typename value_t<TraitsT>::_storage& u) { \
+      PICOJSON_ASSERT("type mismatch! call is<type>() before get<type>()" \
+        && is(type));				        \
+      return jvar; \
+    } \
   }
-  IS(null, null)
-  IS(bool, boolean)
+  ACCESSOR(null, null, u.null_);
+  ACCESSOR(bool, boolean, u.boolean_);
 #ifdef PICOJSON_USE_INT64
-  IS(int64_t, int64)
+  ACCESSOR(int64_t, int64, u.int64_);
 #endif
-  IS(std::string, string)
-  IS(array, array)
-  IS(object, object)
+  ACCESSOR(std::string, string, *u.string_);
+  ACCESSOR(array, array, *u.array_);
+  ACCESSOR(object, object, *u.object_);
 #undef IS
-  template <> inline bool value::is<double>() const {
-    return type_ == number_type
+  template <typename TraitsT>
+  struct _accessor<TraitsT, typename TraitsT::number_traits::value_type> { \
+    static bool is(int type) {
+      return type == number_type
 #ifdef PICOJSON_USE_INT64
-      || type_ == int64_type
+        || type == int64_type
 #endif
-      ;
-  }
-  
-#define GET(ctype, var)						\
-  template <> inline const ctype& value::get<ctype>() const {	\
-    PICOJSON_ASSERT("type mismatch! call is<type>() before get<type>()" \
-	   && is<ctype>());				        \
-    return var;							\
-  }								\
-  template <> inline ctype& value::get<ctype>() {		\
-    PICOJSON_ASSERT("type mismatch! call is<type>() before get<type>()"	\
-	   && is<ctype>());					\
-    return var;							\
-  }
-  GET(bool, u_.boolean_)
-  GET(std::string, *u_.string_)
-  GET(array, *u_.array_)
-  GET(object, *u_.object_)
+        ;
+    }
+    static typename TraitsT::number_traits::value_type& get(int& type, typename value_t<TraitsT>::_storage& u) {
+      PICOJSON_ASSERT("type mismatch! call is<type>() before get<type>()"
+        && is(type));
 #ifdef PICOJSON_USE_INT64
-  GET(double, (type_ == int64_type && (const_cast<value*>(this)->type_ = number_type, const_cast<value*>(this)->u_.number_ = u_.int64_), u_.number_))
-  GET(int64_t, u_.int64_)
-#else
-  GET(double, u_.number_)
+      if (type == int64_type) {
+        type = number_type;
+        TraitsT::number_traits::construct(u.number_, u.int64_);
+      }
 #endif
-#undef GET
-  
-  inline bool value::evaluate_as_boolean() const {
+      return u.number_;
+    }
+  };
+
+  template <typename TraitsT>
+  template <typename T>
+  inline bool value_t<TraitsT>::is() const {
+    return _accessor<TraitsT, T>::is(type_);
+  }
+
+  template <typename TraitsT>
+  template <typename T>
+  inline const T& value_t<TraitsT>::get() const {
+    return const_cast<value_t<TraitsT>*>(this)->get<T>();
+  }
+
+  template <typename TraitsT>
+  template <typename T>
+  inline T& value_t<TraitsT>::get() {
+    return _accessor<TraitsT, T>::get(type_, u_);
+  }
+    
+  template <typename TraitsT>
+  inline bool value_t<TraitsT>::evaluate_as_boolean() const {
     switch (type_) {
     case null_type:
       return false;
     case boolean_type:
       return u_.boolean_;
     case number_type:
-      return u_.number_ != 0;
+      return TraitsT::number_traits::evaluate_as_boolean(u_.number_);
     case string_type:
       return ! u_.string_->empty();
     default:
@@ -323,44 +406,51 @@ namespace picojson {
     }
   }
   
-  inline const value& value::get(size_t idx) const {
-    static value s_null;
+  template <typename TraitsT>
+  inline const value_t<TraitsT>& value_t<TraitsT>::get(size_t idx) const {
+    static value_t s_null;
     PICOJSON_ASSERT(is<array>());
     return idx < u_.array_->size() ? (*u_.array_)[idx] : s_null;
   }
 
-  inline value& value::get(size_t idx) {
-    static value s_null;
+  template <typename TraitsT>
+  inline value_t<TraitsT>& value_t<TraitsT>::get(size_t idx) {
+    static value_t s_null;
     PICOJSON_ASSERT(is<array>());
     return idx < u_.array_->size() ? (*u_.array_)[idx] : s_null;
   }
 
-  inline const value& value::get(const std::string& key) const {
-    static value s_null;
+  template <typename TraitsT>
+  inline const value_t<TraitsT>& value_t<TraitsT>::get(const std::string& key) const {
+    static value_t s_null;
     PICOJSON_ASSERT(is<object>());
-    object::const_iterator i = u_.object_->find(key);
+    typename object::const_iterator i = u_.object_->find(key);
     return i != u_.object_->end() ? i->second : s_null;
   }
 
-  inline value& value::get(const std::string& key) {
-    static value s_null;
+  template <typename TraitsT>
+  inline value_t<TraitsT>& value_t<TraitsT>::get(const std::string& key) {
+    static value_t s_null;
     PICOJSON_ASSERT(is<object>());
-    object::iterator i = u_.object_->find(key);
+    typename object::iterator i = u_.object_->find(key);
     return i != u_.object_->end() ? i->second : s_null;
   }
 
-  inline bool value::contains(size_t idx) const {
+  template <typename TraitsT>
+  inline bool value_t<TraitsT>::contains(size_t idx) const {
     PICOJSON_ASSERT(is<array>());
     return idx < u_.array_->size();
   }
 
-  inline bool value::contains(const std::string& key) const {
+  template <typename TraitsT>
+  inline bool value_t<TraitsT>::contains(const std::string& key) const {
     PICOJSON_ASSERT(is<object>());
-    object::const_iterator i = u_.object_->find(key);
+    typename object::const_iterator i = u_.object_->find(key);
     return i != u_.object_->end();
   }
   
-  inline std::string value::to_str() const {
+  template <typename TraitsT>
+  inline std::string value_t<TraitsT>::to_str() const {
     switch (type_) {
     case null_type:      return "null";
     case boolean_type:   return u_.boolean_ ? "true" : "false";
@@ -371,23 +461,7 @@ namespace picojson {
       return buf;
     }
 #endif
-    case number_type:    {
-      char buf[256];
-      double tmp;
-      SNPRINTF(buf, sizeof(buf), fabs(u_.number_) < (1ULL << 53) && modf(u_.number_, &tmp) == 0 ? "%.f" : "%.17g", u_.number_);
-#if PICOJSON_USE_LOCALE
-      char *decimal_point = localeconv()->decimal_point;
-      if (strcmp(decimal_point, ".") != 0) {
-        size_t decimal_point_len = strlen(decimal_point);
-        for (char *p = buf; *p != '\0'; ++p) {
-          if (strncmp(p, decimal_point, decimal_point_len) == 0) {
-            return std::string(buf, p) + "." + (p + decimal_point_len);
-          }
-        }
-      }
-#endif
-      return buf;
-    }
+    case number_type:    return TraitsT::number_traits::to_str(u_.number_);
     case string_type:    return *u_.string_;
     case array_type:     return "array";
     case object_type:    return "object";
@@ -431,22 +505,29 @@ namespace picojson {
     *oi++ = '"';
   }
 
-  template <typename Iter> void value::serialize(Iter oi, bool prettify) const {
+  template <typename TraitsT>
+  template <typename Iter>
+  void value_t<TraitsT>::serialize(Iter oi, bool prettify) const {
     return _serialize(oi, prettify ? 0 : -1);
   }
   
-  inline std::string value::serialize(bool prettify) const {
+  template <typename TraitsT>
+  inline std::string value_t<TraitsT>::serialize(bool prettify) const {
     return _serialize(prettify ? 0 : -1);
   }
 
-  template <typename Iter> void value::_indent(Iter oi, int indent) {
+  template <typename TraitsT>
+  template <typename Iter>
+  inline void value_t<TraitsT>::_indent(Iter oi, int indent) {
     *oi++ = '\n';
     for (int i = 0; i < indent * INDENT_WIDTH; ++i) {
       *oi++ = ' ';
     }
   }
 
-  template <typename Iter> void value::_serialize(Iter oi, int indent) const {
+  template <typename TraitsT>
+  template <typename Iter>
+  inline void value_t<TraitsT>::_serialize(Iter oi, int indent) const {
     switch (type_) {
     case string_type:
       serialize_str(*u_.string_, oi);
@@ -456,7 +537,7 @@ namespace picojson {
       if (indent != -1) {
         ++indent;
       }
-      for (array::const_iterator i = u_.array_->begin();
+      for (typename array::const_iterator i = u_.array_->begin();
            i != u_.array_->end();
            ++i) {
 	if (i != u_.array_->begin()) {
@@ -481,7 +562,7 @@ namespace picojson {
       if (indent != -1) {
         ++indent;
       }
-      for (object::const_iterator i = u_.object_->begin();
+      for (typename object::const_iterator i = u_.object_->begin();
 	   i != u_.object_->end();
 	   ++i) {
 	if (i != u_.object_->begin()) {
@@ -515,7 +596,8 @@ namespace picojson {
     }
   }
   
-  inline std::string value::_serialize(int indent) const {
+  template <typename TraitsT>
+  inline std::string value_t<TraitsT>::_serialize(int indent) const {
     std::string s;
     _serialize(std::back_inserter(s), indent);
     return s;
@@ -817,57 +899,59 @@ namespace picojson {
     }
   };
   
-  class default_parse_context {
+  template <typename TraitsT>
+  class default_parse_context_t {
   protected:
-    value* out_;
+    value_t<TraitsT>* out_;
   public:
-    default_parse_context(value* out) : out_(out) {}
+    default_parse_context_t(value_t<TraitsT>* out) : out_(out) {}
     bool set_null() {
-      *out_ = value();
+      *out_ = value_t<TraitsT>();
       return true;
     }
     bool set_bool(bool b) {
-      *out_ = value(b);
+      *out_ = value_t<TraitsT>(b);
       return true;
     }
 #ifdef PICOJSON_USE_INT64
     bool set_int64(int64_t i) {
-      *out_ = value(i);
+      *out_ = value_t<TraitsT>(i);
       return true;
     }
 #endif
     bool set_number(double f) {
-      *out_ = value(f);
+      *out_ = value_t<TraitsT>(f);
       return true;
     }
     template<typename Iter> bool parse_string(input<Iter>& in) {
-      *out_ = value(string_type, false);
-      return _parse_string(out_->get<std::string>(), in);
+      *out_ = value_t<TraitsT>(string_type, false);
+      return _parse_string(out_->template get<std::string>(), in);
     }
     bool parse_array_start() {
-      *out_ = value(array_type, false);
+      *out_ = value_t<TraitsT>(array_type, false);
       return true;
     }
     template <typename Iter> bool parse_array_item(input<Iter>& in, size_t) {
-      array& a = out_->get<array>();
-      a.push_back(value());
-      default_parse_context ctx(&a.back());
+      array& a = out_->template get<array>();
+      a.push_back(value_t<TraitsT>());
+      default_parse_context_t ctx(&a.back());
       return _parse(ctx, in);
     }
     bool parse_array_stop(size_t) { return true; }
     bool parse_object_start() {
-      *out_ = value(object_type, false);
+      *out_ = value_t<TraitsT>(object_type, false);
       return true;
     }
     template <typename Iter> bool parse_object_item(input<Iter>& in, const std::string& key) {
-      object& o = out_->get<object>();
-      default_parse_context ctx(&o[key]);
+      object& o = out_->template get<object>();
+      default_parse_context_t ctx(&o[key]);
       return _parse(ctx, in);
     }
   private:
-    default_parse_context(const default_parse_context&);
-    default_parse_context& operator=(const default_parse_context&);
+    default_parse_context_t(const default_parse_context_t&);
+    default_parse_context_t& operator=(const default_parse_context_t&);
   };
+  typedef default_parse_context_t<defaults::type_traits> default_parse_context;
 
   class null_parse_context {
   public:
@@ -901,7 +985,8 @@ namespace picojson {
   };
   
   // obsolete, use the version below
-  template <typename Iter> inline std::string parse(value& out, Iter& pos, const Iter& last) {
+  template <typename Iter, typename TraitsT>
+  inline std::string parse(value_t<TraitsT>& out, Iter& pos, const Iter& last) {
     std::string err;
     pos = parse(out, pos, last, &err);
     return err;
@@ -925,12 +1010,13 @@ namespace picojson {
     return in.cur();
   }
   
-  template <typename Iter> inline Iter parse(value& out, const Iter& first, const Iter& last, std::string* err) {
-    default_parse_context ctx(&out);
+  template <typename Iter, typename TraitsT> inline Iter parse(value_t<TraitsT>& out, const Iter& first, const Iter& last, std::string* err) {
+    default_parse_context_t<TraitsT> ctx(&out);
     return _parse(ctx, first, last, err);
   }
   
-  inline std::string parse(value& out, std::istream& is) {
+  template <typename TraitsT>
+  inline std::string parse(value_t<TraitsT>& out, std::istream& is) {
     std::string err;
     parse(out, std::istreambuf_iterator<char>(is.rdbuf()),
 	  std::istreambuf_iterator<char>(), &err);
@@ -950,12 +1036,13 @@ namespace picojson {
     return last_error_t<bool>::s;
   }
 
-  inline bool operator==(const value& x, const value& y) {
-    if (x.is<null>())
-      return y.is<null>();
+  template <typename TraitsT>
+  inline bool operator==(const value_t<TraitsT>& x, const value_t<TraitsT>& y) {
+    if (x.template is<null>())
+      return y.template is<null>();
 #define PICOJSON_CMP(type)					\
-    if (x.is<type>())						\
-      return y.is<type>() && x.get<type>() == y.get<type>()
+    if (x.template is<type>())						\
+      return y.template is<type>() && x.template get<type>() == y.template get<type>()
     PICOJSON_CMP(bool);
     PICOJSON_CMP(double);
     PICOJSON_CMP(std::string);
@@ -969,19 +1056,19 @@ namespace picojson {
     return false;
   }
   
-  inline bool operator!=(const value& x, const value& y) {
+  template <typename TraitsT>
+  inline bool operator!=(const value_t<TraitsT>& x, const value_t<TraitsT>& y) {
     return ! (x == y);
+  }
+
+  template <typename TraitsT>
+  inline void swap(value_t<TraitsT>& x, value_t<TraitsT>& y) {
+    x.swap(y);
   }
 }
 
-namespace std {
-  template<> inline void swap(picojson::value& x, picojson::value& y)
-    {
-      x.swap(y);
-    }
-}
-
-inline std::istream& operator>>(std::istream& is, picojson::value& x)
+template <typename TraitsT>
+inline std::istream& operator>>(std::istream& is, picojson::value_t<TraitsT>& x)
 {
   picojson::set_last_error(std::string());
   std::string err = picojson::parse(x, is);
@@ -992,7 +1079,8 @@ inline std::istream& operator>>(std::istream& is, picojson::value& x)
   return is;
 }
 
-inline std::ostream& operator<<(std::ostream& os, const picojson::value& x)
+template <typename TraitsT>
+inline std::ostream& operator<<(std::ostream& os, const picojson::value_t<TraitsT>& x)
 {
   x.serialize(std::ostream_iterator<char>(os));
   return os;

--- a/picojson.h
+++ b/picojson.h
@@ -108,7 +108,7 @@ namespace picojson {
   
   namespace defaults {
 
-    struct number_traits {
+    struct default_number_traits {
       typedef double value_type;
       static value_type default_value() { return 0.0; }
       static void construct(value_type &slot, value_type n) {
@@ -157,7 +157,7 @@ namespace picojson {
     };
 
     struct type_traits {
-      typedef number_traits number_traits;
+      typedef default_number_traits number_traits;
     };
 
   }


### PR DESCRIPTION
My current progress on #51 . It isn't designed to be merged just yet, but I wanted to check the state before continuing.

There are minimal changes to picojson.h, mainly just tidying up some places where the type traits weren't used (refering to array and object), and some (in my opinion) slight neatening. In particular, there is no explicit reference to my header, which is nice.

The only thing which caused me trouble is that my type must be storable in a union, so must be a pointer. I added a pair of traits(return_type and to_return_type) which givea way of storing a pointer in the union (like object/array), or the raw object (like double already is).

I would like to be able to run all the tests for my interface, but that is proving irritatingly fiddly. One option would be to pull the tests out into a seperate file?

I could also look at abstracting out the int64 in a similar way, which would get all int64 out of picojson.h (at the cost of changing the current int64 interface, and making int64s a bit less efficient because of another layer. Depends how much / if at all you would like it out..)
