### PR TITLE
Updated Makefile to include install/uninstall targets.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+prefix=/usr/local
+includedir=$(prefix)/include
+
 test:
 	$(MAKE) test-core
 	$(MAKE) test-core TEST_OPTS=-DPICOJSON_USE_INT64
@@ -5,4 +8,11 @@ test:
 test-core:
 	$(CXX) -o test-core -Wall $(TEST_OPTS) -DTEST_PICOJSON -x c++ - < picojson.h && ./test-core
 
-.PHONY: test test-core
+install:
+	install -d $(DESTDIR)$(includedir)
+	install -p -m 0644 picojson.h $(DESTDIR)$(includedir)
+
+uninstall:
+	rm -f $(DESTDIR)$(includedir)/picojson.h
+
+.PHONY: test test-core install uninstall


### PR DESCRIPTION
The install/uninstall targets make is easier to create distro packages for OpenSUSE, Fedora, Debian, etc.
