### PR TITLE
make operator= safe when part of LHS is being assigned

### DIFF
--- a/picojson.h
+++ b/picojson.h
@@ -253,8 +253,8 @@ namespace picojson {
   
   inline value& value::operator=(const value& x) {
     if (this != &x) {
-      this->~value();
-      new (this) value(x);
+      value t(x);
+      swap(t);
     }
     return *this;
   }


### PR DESCRIPTION
Also makes the operator exception-safe (the object would be left unmodified if exception is thrown).

fixes #65 