### PR TITLE
fix "'NULL' is not declared in this scope" error.

### DIFF
--- a/picojson.h
+++ b/picojson.h
@@ -32,6 +32,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <cstddef>
 #include <iostream>
 #include <iterator>
 #include <limits>


### PR DESCRIPTION
on the following environment:

- Linux devel 3.13.0-32-generic #57-Ubuntu SMP Tue Jul 15 03:51:08 UTC 2014 x86_64 x86_64 x86_64 GNU/Linux
- gcc (Ubuntu 4.8.2-19ubuntu1) 4.8.2