### PR TITLE
picojson::value((int64_t) 0).evaluate_as_boolean() should be false

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,10 @@ test: test-core test-core-int64
 	./test-core
 	./test-core-int64
 
-test-core: test.cc picotest/picotest.c picotest/picotest.h
+test-core: picojson.h test.cc picotest/picotest.c picotest/picotest.h
 	$(CXX) -Wall test.cc picotest/picotest.c -o $@
 
-test-core-int64: test.cc picotest/picotest.c picotest/picotest.h
+test-core-int64: picojson.h test.cc picotest/picotest.c picotest/picotest.h
 	$(CXX) -Wall -DPICOJSON_USE_INT64 test.cc picotest/picotest.c -o $@
 
 clean:

--- a/picojson.h
+++ b/picojson.h
@@ -317,6 +317,10 @@ namespace picojson {
       return u_.boolean_;
     case number_type:
       return u_.number_ != 0;
+#ifdef PICOJSON_USE_INT64
+    case int64_type:
+      return u_.int64_ != 0;
+#endif
     case string_type:
       return ! u_.string_->empty();
     default:

--- a/test.cc
+++ b/test.cc
@@ -308,5 +308,18 @@ int main(void)
     is(v.get<picojson::array>()[1].get<std::string>(), "abc", "simple API value #1");
   }
 
+  {
+    picojson::value v1((double) 0);
+    _ok(! v1.evaluate_as_boolean(), "((double) 0) is false");
+    picojson::value v2((double) 1);
+    _ok(v2.evaluate_as_boolean(), "((double) 1) is true");
+#ifdef PICOJSON_USE_INT64
+    picojson::value v3((int64_t) 0);
+    _ok(! v3.evaluate_as_boolean(), "((int64_t) 0) is false");
+    picojson::value v4((int64_t) 1);
+    _ok(v4.evaluate_as_boolean(), "((int64_t) 1) is true");
+#endif
+  }
+
   return done_testing();
 }


### PR DESCRIPTION
"0" means false with evaluate_as_boolean if PICOJSON_USE_INT64 is disabled,
but it means true if PICOJSON_USE_INT64 is enabled.