### PR TITLE
Added openSUSE spec file.

### DIFF
--- a/openSUSE/picojson.changes
+++ b/openSUSE/picojson.changes
@@ -1,0 +1,37 @@
+-------------------------------------------------------------------
+Thu Oct  8 19:56:10 UTC 2015 - kapil@ccs.neu.edu
+
+- Updated to new upstream release v1.3.0 that fixes make test.
+- Upstream Release Notes:
+  - make check is now synonym of make test (#62)
+  - operator= is now safe when part of LHS is being assigned, as well as
+    exception-safe (#66)
+
+-------------------------------------------------------------------
+Tue Dec 16 13:01:03 UTC 2014 - kapil@ccs.neu.edu
+
+- Updated to new upstream release v1.2.1 that fixes make test.
+
+-------------------------------------------------------------------
+Mon Dec 15 12:36:52 UTC 2014 - kapil@ccs.neu.edu
+
+- The upstream tarball is missing some files required for tests;
+  we disable the tests until the next release (that will include
+  all required files).
+
+-------------------------------------------------------------------
+Mon Dec 15 12:25:47 UTC 2014 - kapil@ccs.neu.edu
+
+- Updated to upstream release 1.2.0.
+
+-------------------------------------------------------------------
+Thu Dec 11 23:14:52 UTC 2014 - jengelh@inai.de
+
+- Cleanups: Remove BuildRequires for implicit packages. Add missing
+  %defattr line. Add upstream project metadata into the spec file.
+  Reword description a bit (more prose-y).
+
+-------------------------------------------------------------------
+Wed Dec 10 23:26:35 UTC 2014 - kapil@ccs.neu.edu
+
+- Initial picojson package (version 1.1.2) for OpenSUSE.

--- a/openSUSE/picojson.spec
+++ b/openSUSE/picojson.spec
@@ -1,0 +1,65 @@
+#
+# spec file for package picojson
+#
+# Copyright (c) 2014 Kapil Arya <kapil@mesosphere.io>
+#
+# All modifications and additions to the file contributed by third parties
+# remain the property of their copyright owners, unless otherwise agreed
+# upon. The license for this file, and modifications and additions to the
+# file, is the same license as for the pristine package itself (unless the
+# license for the pristine package is not an Open Source License, in which
+# case the license is the MIT License). An "Open Source License" is a
+# license that conforms to the Open Source Definition (Version 1.9)
+# published by the Open Source Initiative.
+
+# Please submit bugfixes or comments via http://bugs.opensuse.org/
+#
+
+Name:           picojson
+Version:        1.3.0
+Release:        0
+Summary:        A header-file-only, JSON parser / serializer in C++
+License:        BSD-2-Clause
+URL:            https://github.com/kazuho/picojson
+Group:		Development/Libraries/C++
+
+#Git-Clone:	git://github.com/kazuho/picojson
+Source: 	%{name}-%{version}.tar.gz
+BuildRequires:  gcc-c++
+
+%description
+PicoJSON is a tiny JSON parser / serializer for C++. It is implemented as
+header-only, has no external dependencies, is STL-friendly (using std::vector
+and std::map only), and provides both streaming (event-based) and a pull
+interface.
+This package provides the picojson header file(s).
+
+%package devel
+Summary:        Header files for picojson development
+Group:          Development/Libraries/C and C++
+Provides:       %{name}-static = %{version}-%{release}
+
+%description devel
+PicoJSON is a tiny JSON parser / serializer for C++. It is implemented as
+header-only, has no external dependencies, is STL-friendly (using std::vector
+and std::map only), and provides both streaming (event-based) and a pull
+interface.
+This package provides the picojson header file(s).
+
+%prep
+%setup -q
+
+%build
+
+%check
+make test
+
+%install
+make install includedir=%{_includedir} DESTDIR=%{buildroot} %{?_smp_mflags}
+
+%files devel
+%defattr(-,root,root)
+%{_includedir}/picojson.h
+%doc LICENSE README.mkdn examples
+
+%changelog


### PR DESCRIPTION
Picojson is now in openSUSE Factory (http://software.opensuse.org/package/picojson) and will be part of the next major release.