### PR TITLE
do not consume extra char when parsing a scalar number

### DIFF
--- a/test.cc
+++ b/test.cc
@@ -324,9 +324,12 @@ int main(void)
   {
     picojson::value v;
     std::string err;
-    const char *s = "[1]X";
+    const char *s = "123abc";
     const char *reststr = picojson::parse(v, s, s + strlen(s), &err);
-    is(*reststr, 'X', "parse function doesn't consume last char");
+    _ok(err.empty(), "should succeed");
+    _ok(v.is<double>(), "is number");
+    _ok(v.get<double>() == 123.0, "is 123");
+    is(*reststr, 'a', "should point at the next char");
   }
 
   return done_testing();

--- a/test.cc
+++ b/test.cc
@@ -321,5 +321,13 @@ int main(void)
 #endif
   }
 
+  {
+    picojson::value v;
+    std::string err;
+    const char *s = "[1]X";
+    const char *reststr = picojson::parse(v, s, s + strlen(s), &err);
+    is(*reststr, 'X', "parse function doesn't consume last char");
+  }
+
   return done_testing();
 }


### PR DESCRIPTION
Current implementation of `class input` increments the input iterator when `getc()` is called.  Therefore, when `ungetc()` is called laterwards and then if the parse function returns, the iterator will point at next to the end position of JSON.
note: this becomes an issue only when the input is a scalar number; to parse JSON input (number) like: `123abc`, the parser needs to read `a`, call `ungetc()`, and then return

This PR fixes the issue by delaying the moment when the iterator gets incremented, until to when the next character is fetched by the parser.