### PR TITLE
add bracket operator and opt

### DIFF
--- a/picojson.h
+++ b/picojson.h
@@ -156,12 +156,16 @@ namespace picojson {
     void swap(value& x)throw();
     template <typename T> bool is() const;
     template <typename T> const T& get() const;
+    template <typename T> const T& opt(const T& fallback) const;
     template <typename T> T& get();
     bool evaluate_as_boolean() const;
     const value& get(size_t idx) const;
     const value& get(const std::string& key) const;
     value& get(size_t idx);
     value& get(const std::string& key);
+
+    const value & operator[](size_t i) const;
+    const value & operator[](const std::string &key) const;
 
     bool contains(size_t idx) const;
     bool contains(const std::string& key) const;
@@ -349,7 +353,14 @@ namespace picojson {
       return true;
     }
   }
-  
+
+  template <typename T> const T& value::opt(const T& fallback) const{
+    if(!is<T>()){
+      return fallback;
+    }
+    return get<T>();
+  }
+
   inline const value& value::get(size_t idx) const {
     static value s_null;
     PICOJSON_ASSERT(is<array>());
@@ -374,6 +385,26 @@ namespace picojson {
     PICOJSON_ASSERT(is<object>());
     object::iterator i = u_.object_->find(key);
     return i != u_.object_->end() ? i->second : s_null;
+  }
+
+  inline const value & value::operator[](size_t i) const {
+    if(!is<array>()) {
+      static const value s_null;
+      return s_null;
+    }
+    else {
+      return get(i);
+    }
+  }
+
+  inline const value & value::operator[](const std::string &key) const {
+    if(!is<object>()) {
+      static const value s_null;
+      return s_null;
+    }
+    else {
+      return get(key);
+    }
   }
 
   inline bool value::contains(size_t idx) const {

--- a/test.cc
+++ b/test.cc
@@ -332,5 +332,25 @@ int main(void)
     is(*reststr, 'a', "should point at the next char");
   }
 
+  {
+    picojson::value v;
+    const char *s = "{ \"a\": [1,\"str\"] , \"b\": true ,\"o\":{\"o\":{\"v\": true}}}";
+    string err = picojson::parse(v, s, s + strlen(s));
+    _ok(err.empty(), "object no error");
+    _ok(v.is<picojson::object>(), "object check type");
+    _ok(v.contains("a"), "check contains property");
+    is(v.get("b").opt(false), true, "check bool property value");
+    is(v.get("c").opt(true), true, "check not contains property fallback value");
+    is(v.get("c").opt(false), false, "check not contains property fallback value");
+
+    is(v["o"]["o"]["v"].opt(false), true, "check bool property value");
+    is(v["b"]["o"]["v"].opt(true), true, "check not contains property fallback value");
+    is(v["c"]["o"]["v"].opt(true), true, "check not contains property fallback value");
+    is(v["c"]["o"]["v"].opt(false), false, "check not contains property fallback value");
+    is(v["a"][0].is<double>(), true, "check a[0] type");
+    is(v["a"][1].is<string>(), true, "check a[1] type");
+    is(v["b"][3].opt(true), true, "check not contains property fallback value");
+  }
+
   return done_testing();
 }


### PR DESCRIPTION
Motivation.
If the value does not exist, want to assign from default value, but it requires a error checking.

e.g. want get "sample" if "a.b" is a std::string.  "default" otherwise.
```json
{"a":{"b":"sample"}}
```
current vesion
```C++
  std::string result = "default";
  if(v.is<picojson::object>())
  {
    const picojson::value& a =  v.get("a");
    if(a.is<picojson::object>())
    {
      const picojson::value& b = a.get("b");
      result = b.is<std::string>()? b.get<std::string>():result;
    }
  }
```

with this PR.
```C++
std::string result = v["a"]["b"].opt(std::string("default"));
```
It's simple!