### PR TITLE
fix -Wcatch-value warnings with gcc8

### DIFF
--- a/test.cc
+++ b/test.cc
@@ -268,14 +268,14 @@ int main(void)
   try {
     picojson::value v(std::numeric_limits<double>::quiet_NaN());
     _ok(false, "should not accept NaN");
-  } catch (std::overflow_error e) {
+  } catch (std::overflow_error& e) {
     _ok(true, "should not accept NaN");
   }
 
   try {
     picojson::value v(std::numeric_limits<double>::infinity());
     _ok(false, "should not accept infinity");
-  } catch (std::overflow_error e) {
+  } catch (std::overflow_error& e) {
     _ok(true, "should not accept infinity");
   }
 
@@ -284,7 +284,7 @@ int main(void)
     _ok(! v.is<bool>(), "is<wrong_type>() should return false");
     v.get<bool>();
     _ok(false, "get<wrong_type>() should raise an error");
-  } catch (std::runtime_error e) {
+  } catch (std::runtime_error& e) {
     _ok(true, "get<wrong_type>() should raise an error");
   }
 


### PR DESCRIPTION
+ make test
g++ -Wall test.cc picotest/picotest.c -o test-core
test.cc: In function 'int main()':
test.cc:259:32: warning: catching polymorphic type 'class std::overflow_error' by value [-Wcatch-value=]
   } catch (std::overflow_error e) {
                                ^
test.cc:266:32: warning: catching polymorphic type 'class std::overflow_error' by value [-Wcatch-value=]
   } catch (std::overflow_error e) {
                                ^
test.cc:275:31: warning: catching polymorphic type 'class std::runtime_error' by value [-Wcatch-value=]
   } catch (std::runtime_error e) {
                               ^
g++ -Wall -DPICOJSON_USE_INT64 test.cc picotest/picotest.c -o test-core-int64
test.cc: In function 'int main()':
test.cc:259:32: warning: catching polymorphic type 'class std::overflow_error' by value [-Wcatch-value=]
   } catch (std::overflow_error e) {
                                ^
test.cc:266:32: warning: catching polymorphic type 'class std::overflow_error' by value [-Wcatch-value=]
   } catch (std::overflow_error e) {
                                ^
test.cc:275:31: warning: catching polymorphic type 'class std::runtime_error' by value [-Wcatch-value=]
   } catch (std::runtime_error e) {
                               ^
