### PR TITLE
fix compiler error under C++03 with `isnan`, `isinf` provided as functions

### DIFF
--- a/picojson.h
+++ b/picojson.h
@@ -239,7 +239,7 @@ inline value::value(double n) : type_(number_type), u_() {
   if (
 #ifdef _MSC_VER
       !_finite(n)
-#elif __cplusplus >= 201103L || !(defined(isnan) && defined(isinf))
+#elif __cplusplus >= 201103L
       std::isnan(n) || std::isinf(n)
 #else
       isnan(n) || isinf(n)


### PR DESCRIPTION
rather than as macros