### PR TITLE
Add PICOJSON_DISABLE_EXCEPTION macro switch to support -fno-exceptions

### DIFF
--- a/picojson.h
+++ b/picojson.h
@@ -91,11 +91,19 @@ extern "C" {
 #endif
 
 #ifndef PICOJSON_ASSERT
+#ifndef PICOJSON_DISABLE_EXCEPTION
 #define PICOJSON_ASSERT(e)                                                                                                         \
   do {                                                                                                                             \
     if (!(e))                                                                                                                      \
       throw std::runtime_error(#e);                                                                                                \
   } while (0)
+#else
+#define PICOJSON_ASSERT(e)                                                                                                         \
+  do {                                                                                                                             \
+    if (!(e))                                                                                                                      \
+      std::abort();                                                                                                                \
+  } while (0)
+#endif  // PICOJSON_DISABLE_EXCEPTION
 #endif
 
 #ifdef _MSC_VER
@@ -245,7 +253,11 @@ inline value::value(double n) : type_(number_type), u_() {
       isnan(n) || isinf(n)
 #endif
           ) {
+#ifndef PICOJSON_DISABLE_EXCEPTION
     throw std::overflow_error("");
+#else
+    std::abort();
+#endif
   }
   u_.number_ = n;
 }


### PR DESCRIPTION
Fixes #117 

For supporting `-fno-exceptions` compiler option, this patch adds `PICOJSON_DISABLE_EXCEPTION` preprocessor macro switch. When it is defined, picojson utilizes `std::abort` instead of `throw`.

I confirmed `picojson.h` can be compiled with `clang++ -fno-exception` with this patch and all tests passed by `make test`.