### PR TITLE
fix compiler warning on __STDC_FORMAT_MACROS redef

### DIFF
--- a/picojson.h
+++ b/picojson.h
@@ -75,7 +75,9 @@ extern "C" {
 
 // experimental support for int64_t (see README.mkdn for detail)
 #ifdef PICOJSON_USE_INT64
+#ifndef __STDC_FORMAT_MACROS
 #define __STDC_FORMAT_MACROS
+#endif
 #include <cerrno>
 #if __cplusplus >= 201103L
 #include <cinttypes>


### PR DESCRIPTION
Fixes #91 

Without this, if I include 2 libraries that define this macro, I get warnings like

```
warning: '__STDC_FORMAT_MACROS' macro redefined [-Wmacro-redefined]
```

This is on macos 10.15 with AppleClang 11.