### PR TITLE
Fix build error in first sample code in README

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -29,7 +29,7 @@ std::string json = "[ \"hello JSON\" ]";
 picojson::value v;
 std::string err = picojson::parse(v, json);
 if (! err.empty()) {
-  std:cerr << err << std::endl;
+  std::cerr << err << std::endl;
 }
 ```
 


### PR DESCRIPTION
I first thought that to get the sample code to compile, I had to add `using namespace std;` - and then the second time I copied it, I realised that there was a colon missing in `std:err`....

Hopefully this might help others....