### PR TITLE
Disabled warning 4706 under Visual Studio (fixes kazuho/picojson#129)

### DIFF
--- a/picojson.h
+++ b/picojson.h
@@ -110,6 +110,7 @@ extern "C" {
 #pragma warning(disable : 4244) // conversion from int to char
 #pragma warning(disable : 4127) // conditional expression is constant
 #pragma warning(disable : 4702) // unreachable code
+#pragma warning(disable : 4706) // assignment within conditional expression
 #else
 #define SNPRINTF snprintf
 #endif


### PR DESCRIPTION
Fixes kazuho/picojson#129.