### PR TITLE
Fix deny_parse_context class

### DIFF
--- a/picojson.h
+++ b/picojson.h
@@ -961,6 +961,9 @@ public:
   template <typename Iter> bool parse_object_item(input<Iter> &, const std::string &) {
     return false;
   }
+  bool parse_object_stop() {
+    return false;
+  }  
 };
 
 class default_parse_context {


### PR DESCRIPTION
After https://github.com/kazuho/picojson/commit/35ce0b6b03e0b60541258f5ad061003a696d9a34 commit the parse_object_stop() function is required to be in the parse context class. But this function isn't added to deny_parse_context class, that breaks programs which use this class as base.

This adds default parse_object_stop() function to deny_parse_context class to solve issue.