### PR TITLE
Added SPDX license identifier

### DIFF
--- a/picojson.h
+++ b/picojson.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: BSD-2-Clause
 /*
  * Copyright 2009-2010 Cybozu Labs, Inc.
  * Copyright 2011-2014 Kazuho Oku


### PR DESCRIPTION
This could help in software packages integration, license conformance, etc See https://spdx.dev/ . Moreover, a warning about sign mismatch has been silenced.