### PR TITLE
fix: using stream operator not set eofbit

### DIFF
--- a/picojson.h
+++ b/picojson.h
@@ -1132,7 +1132,12 @@ inline std::string parse(value &out, const std::string &s) {
 
 inline std::string parse(value &out, std::istream &is) {
   std::string err;
-  parse(out, std::istreambuf_iterator<char>(is.rdbuf()), std::istreambuf_iterator<char>(), &err);
+  const auto &beg = std::istreambuf_iterator<char>(is.rdbuf());
+  const auto &end = std::istreambuf_iterator<char>();
+  parse(out, beg, end, &err);
+  if (beg == end) {
+    is.setstate(std::ios_base::eofbit);
+  }
   return err;
 }
 


### PR DESCRIPTION
In the current version, there are the following issue

````cpp
#include <iostream>
#include "picojson.hpp"

int main()
{
    while (!std::cin.eof()) // won't break
    {
        picojson::value v;
        std::cin >> v;
        // processing
        const auto &err = picojson::get_last_error();
        std::cout << "err: " << err << std::endl;
        std::cout << "res: " << v << std::endl;
    }
    return 0;
}
````

at `Line 6`, when read `eof` state from `std::cin` always return `false`.


fix: add `beg/end` judge in `parse(value &out, std::istream &is)` at `Line 1135`

````cpp
inline std::string parse(value &out, std::istream &is) {
  std::string err;
  const auto &beg = std::istreambuf_iterator<char>(is.rdbuf());
  const auto &end = std::istreambuf_iterator<char>();
  parse(out, beg, end, &err);
  if (beg == end) {
    is.setstate(std::ios_base::eofbit); // set eof state because stream has no more data available
  }
  return err;
}
````