### PR TITLE
Proposed macro to override throw #148

### DIFF
--- a/picojson.h
+++ b/picojson.h
@@ -104,7 +104,7 @@ extern "C" {
 #define PICOJSON_ASSERT(e)                                                                                                         \
   do {                                                                                                                             \
     if (!(e))                                                                                                                      \
-      PICOJSON_THROW(std::runtime_error(#e));                                                                                      \
+      PICOJSON_THROW(std::runtime_error, #e);                                                                                      \
   } while (0)
 #endif
 
@@ -256,7 +256,7 @@ inline value::value(double n) : type_(number_type), u_() {
       isnan(n) || isinf(n)
 #endif
   ) {
-    PICOJSON_THROW(std::overflow_error(""));
+    PICOJSON_THROW(std::overflow_error, "");
   }
   u_.number_ = n;
 }

--- a/picojson.h
+++ b/picojson.h
@@ -96,11 +96,15 @@ extern "C" {
 }
 #endif
 
+#ifndef PICOJSON_THROW
+#define PICOJSON_THROW(e, m) throw e(m)
+#endif
+
 #ifndef PICOJSON_ASSERT
 #define PICOJSON_ASSERT(e)                                                                                                         \
   do {                                                                                                                             \
     if (!(e))                                                                                                                      \
-      throw std::runtime_error(#e);                                                                                                \
+      PICOJSON_THROW(std::runtime_error(#e));                                                                                      \
   } while (0)
 #endif
 
@@ -251,8 +255,8 @@ inline value::value(double n) : type_(number_type), u_() {
 #else
       isnan(n) || isinf(n)
 #endif
-          ) {
-    throw std::overflow_error("");
+  ) {
+    PICOJSON_THROW(std::overflow_error(""));
   }
   u_.number_ = n;
 }


### PR DESCRIPTION
The issue of switching throw to abort is similar to #117 and #118.
In this assignment, replace throw with a macro so that exception messages can be handled by the application.

Prepare a macro named `PICOJSON_THROW`.

```c++
// add new macro
#ifndef PICOJSON_THROW
#define PICOJSON_THROW(e, m) throw e(m)
#endif

// replace throw
#ifndef PICOJSON_ASSERT
#define PICOJSON_ASSERT(e) \
  do { \
    if (!(e)) \
      PICOJSON_THROW(std::runtime_error, #e); \
  } while (0)
#endif
```

The application side overwrites abort and assert to use it.
`#define PICOJSON_THROW(e, m) { puts(#e ":" m); abort(); }`
