### PR TITLE
Fix warnings with gcc-12 & improve Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,10 @@ test: test-core test-core-int64
 	./test-core-int64
 
 test-core: picojson.h test.cc picotest/picotest.c picotest/picotest.h
-	$(CXX) -Wall test.cc picotest/picotest.c -o $@
+	$(CXX) $(CXXFLAGS) -Wall test.cc picotest/picotest.c -o $@
 
 test-core-int64: picojson.h test.cc picotest/picotest.c picotest/picotest.h
-	$(CXX) -Wall -DPICOJSON_USE_INT64 test.cc picotest/picotest.c -o $@
+	$(CXX) $(CXXFLAGS) -Wall -DPICOJSON_USE_INT64 test.cc picotest/picotest.c -o $@
 
 clean:
 	rm -f test-core test-core-int64

--- a/picojson.h
+++ b/picojson.h
@@ -151,7 +151,7 @@ public:
 
 protected:
   int type_;
-  _storage u_;
+  _storage u_ = {};
 
 public:
   value();

--- a/test.cc
+++ b/test.cc
@@ -358,6 +358,7 @@ int main(void)
     std::string s = "[{\"a\":123}]", err;
     picojson::value v;
     picojson::default_parse_context ctx(&v, 1);
+    __attribute__((unused))
     std::string::const_iterator end = picojson::_parse(ctx, s.begin(), s.end(), &err);
     _ok(!err.empty(), "should fail");
     _ok(v.is<picojson::array>(), "should get an array");
@@ -367,6 +368,7 @@ int main(void)
   {
     std::string s = "[{\"a\":123}]", err;
     picojson::null_parse_context ctx(1);
+    __attribute__((unused))
     std::string::const_iterator end = picojson::_parse(ctx, s.begin(), s.end(), &err);
     _ok(!err.empty(), "should fail");
   }


### PR DESCRIPTION
Valijson uses picojson as a driver, and we found that building with gcc-12 and optimization (e.g. -O2) causes picojson to emit warnings, see the long story [here](https://github.com/tristanpenman/valijson/issues/164). The most important one is the uninitialized storage warning, which only appears with optimization and gcc-12.
Since master had a few updates since the last release, the changes in this PR are fewer than for valijson, but they are still necessary to compile cleanly e.g. in projects that use -Werror (which is generally not recommended, but still..).
The Makefile fix allows to pass in CXXFLAGS to build/test with different optimization flags.
