### PR TITLE
Do not escape slash

### DIFF
--- a/picojson.h
+++ b/picojson.h
@@ -536,7 +536,6 @@ template <typename Iter> struct serialize_str_char {
     break
       MAP('"', "\\\"");
       MAP('\\', "\\\\");
-      MAP('/', "\\/");
       MAP('\b', "\\b");
       MAP('\f', "\\f");
       MAP('\n', "\\n");


### PR DESCRIPTION
I cannot see in the spec that slash should be escaped.