### PR TITLE
Development package files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *~
+/build/
 a.out
 test-core
 test-core-int64

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,65 @@
+cmake_minimum_required(VERSION 3.16)
+project(picojson
+    VERSION 1.3.0
+    LANGUAGES CXX
+)
+
+include(GNUInstallDirs)
+
+set(INCLUDE_INSTALL_DIR "${CMAKE_INSTALL_INCLUDEDIR}"
+    CACHE PATH "Location of header files"
+)
+
+add_library(picojson INTERFACE)
+add_library(picojson::picojson ALIAS picojson)
+target_include_directories(picojson INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+
+install(FILES picojson.h
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/"
+)
+
+if(NOT WIN32)
+    # Install pkg-config file
+    set(prefix "${CMAKE_INSTALL_PREFIX}")
+    set(includedir "${CMAKE_INSTALL_FULL_INCLUDEDIR}")
+    set(version ${PROJECT_VERSION})
+    configure_file(picojson.pc.in
+        "${CMAKE_CURRENT_BINARY_DIR}/picojson.pc"
+        NEWLINE_STYLE UNIX
+        @ONLY
+    )
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/picojson.pc"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/pkgconfig"
+    )
+endif()
+
+install(TARGETS picojson EXPORT picojson-targets
+    INCLUDES DESTINATION include
+)
+
+set(config_package_location ${CMAKE_INSTALL_LIBDIR}/cmake/picojson)
+install(EXPORT picojson-targets
+    FILE picojson-targets.cmake
+    NAMESPACE picojson::
+    DESTINATION ${config_package_location}
+)
+
+include(CMakePackageConfigHelpers)
+configure_package_config_file(picojson-config.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/picojson-config.cmake
+    INSTALL_DESTINATION ${config_package_location}
+    PATH_VARS INCLUDE_INSTALL_DIR
+)
+write_basic_package_version_file(
+    "${CMAKE_CURRENT_BINARY_DIR}/picojson-config-version.cmake"
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY SameMajorVersion
+    ARCH_INDEPENDENT
+)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/picojson-config.cmake
+              ${CMAKE_CURRENT_BINARY_DIR}/picojson-config-version.cmake
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/picojson
+)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ project(picojson
 
 include(GNUInstallDirs)
 
+option(PKGCONFIG_RELOCATABLE "Create a pkgconfig file with relocatable path" OFF)
 set(INCLUDE_INSTALL_DIR "${CMAKE_INSTALL_INCLUDEDIR}"
     CACHE PATH "Location of header files"
 )
@@ -23,9 +24,13 @@ install(FILES picojson.h
 
 if(NOT WIN32)
     # Install pkg-config file
-    set(prefix "${CMAKE_INSTALL_PREFIX}")
-    set(includedir "${CMAKE_INSTALL_FULL_INCLUDEDIR}")
-    set(version ${PROJECT_VERSION})
+    if(PKGCONFIG_RELOCATABLE)
+        set(prefix "\${pcfiledir}/../..")
+        set(includedir "\${prefix}/include")
+    else()
+        set(prefix "${CMAKE_INSTALL_PREFIX}")
+        set(includedir "${CMAKE_INSTALL_FULL_INCLUDEDIR}")
+    endif()
     configure_file(picojson.pc.in
         "${CMAKE_CURRENT_BINARY_DIR}/picojson.pc"
         NEWLINE_STYLE UNIX

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 prefix=/usr/local
 includedir=$(prefix)/include
 libdir=$(prefix)/lib
+ifdef pkgconfig_relocatable
+CMAKE_EXTRA_ARGS=-DPKGCONFIG_RELOCATABLE=TRUE
+endif
 
 check: test
 
@@ -20,7 +23,7 @@ clean:
 
 install:
 	mkdir -p build
-	cmake -DCMAKE_INSTALL_PREFIX=$(prefix) -DCMAKE_INSTALL_INCLUDEDIR=$(includedir) -S . -B build
+	cmake -DCMAKE_INSTALL_PREFIX=$(prefix) -DCMAKE_INSTALL_INCLUDEDIR=$(includedir) $(CMAKE_EXTRA_ARGS) -S . -B build
 	cmake --build build --target install
 
 uninstall:

--- a/Makefile
+++ b/Makefile
@@ -15,20 +15,20 @@ test-core-int64: picojson.h test.cc picotest/picotest.c picotest/picotest.h
 	$(CXX) -Wall -DPICOJSON_USE_INT64 test.cc picotest/picotest.c -o $@
 
 clean:
+	rm -fr build
 	rm -f test-core test-core-int64
 
 install:
-	install -d $(DESTDIR)$(includedir)
-	install -p -m 0644 picojson.h $(DESTDIR)$(includedir)
-	install -d $(DESTDIR)$(libdir)/pkgconfig
-	sed -e "s:@prefix@:$(prefix):" \
-		-e "s:@includedir@:$(includedir):" \
-		picojson.pc.in > $(DESTDIR)$(libdir)/pkgconfig/picojson.pc
-	chmod 0644 $(DESTDIR)$(libdir)/pkgconfig/picojson.pc
+	mkdir -p build
+	cmake -DCMAKE_INSTALL_PREFIX=$(prefix) -DCMAKE_INSTALL_INCLUDEDIR=$(includedir) -S . -B build
+	cmake --build build --target install
 
 uninstall:
 	rm -f $(DESTDIR)$(includedir)/picojson.h
 	rm -f $(DESTDIR)$(libdir)/pkgconfig/picojson.pc
+	rm -f $(DESTDIR)$(libdir)/cmake/picojson/picojson-config.cmake
+	rm -f $(DESTDIR)$(libdir)/cmake/picojson/picojson-config-version.cmake
+	rm -f $(DESTDIR)$(libdir)/cmake/picojson/picojson-targets.cmake
 
 clang-format: picojson.h examples/github-issues.cc examples/iostream.cc examples/streaming.cc
 	clang-format -i $?

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 prefix=/usr/local
 includedir=$(prefix)/include
+libdir=$(prefix)/lib
 
 check: test
 
@@ -19,9 +20,15 @@ clean:
 install:
 	install -d $(DESTDIR)$(includedir)
 	install -p -m 0644 picojson.h $(DESTDIR)$(includedir)
+	install -d $(DESTDIR)$(libdir)/pkgconfig
+	sed -e "s:@prefix@:$(prefix):" \
+		-e "s:@includedir@:$(includedir):" \
+		picojson.pc.in > $(DESTDIR)$(libdir)/pkgconfig/picojson.pc
+	chmod 0644 $(DESTDIR)$(libdir)/pkgconfig/picojson.pc
 
 uninstall:
 	rm -f $(DESTDIR)$(includedir)/picojson.h
+	rm -f $(DESTDIR)$(libdir)/pkgconfig/picojson.pc
 
 clang-format: picojson.h examples/github-issues.cc examples/iostream.cc examples/streaming.cc
 	clang-format -i $?

--- a/picojson-config.cmake.in
+++ b/picojson-config.cmake.in
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/picojson-targets.cmake")
+
+check_required_components(picojson)

--- a/picojson.pc.in
+++ b/picojson.pc.in
@@ -3,5 +3,5 @@ includedir=@includedir@
 
 Name: picojson
 Description: Tiny JSON parser / serializer for C++
-Version: 1.3.0
+Version: @version@
 Cflags: -I${includedir}

--- a/picojson.pc.in
+++ b/picojson.pc.in
@@ -1,0 +1,7 @@
+prefix=@prefix@
+includedir=@includedir@
+
+Name: picojson
+Description: Tiny JSON parser / serializer for C++
+Version: 1.3.0
+Cflags: -I${includedir}


### PR DESCRIPTION
Add development package files for both:

* pkgconfig
* CMake

These make it easier for downstream projects and (distro) packagers to package and use the projects, as well as chaining library dependencies.